### PR TITLE
Uncomment config module

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,17 @@ go!(move || {
 
 ```
 
+### 3. Load configuration
+Lifeguard can read `config/config.toml` or environment variables with the
+`LIFEGUARD__` prefix.
+
+```rust
+use lifeguard::{DbPoolManager, config::DatabaseConfig};
+
+let cfg = DatabaseConfig::load()?;
+let pool = DbPoolManager::from_config(&cfg)?;
+```
+
 ---
 
 ### 🧪 Development & Testing

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,7 @@
+//! Configuration utilities re-exported at the crate root.
+//!
+//! This exposes [`DatabaseConfig`] so applications can load settings
+//! from `config/config.toml` or environment variables using
+//! `DatabaseConfig::load()`.
+
+pub use crate::pool::config::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! See [README on GitHub](https://github.com/microscaler/lifeguard)
 
-// pub mod config;
+pub mod config;
 
 mod macros;
 pub mod metrics;


### PR DESCRIPTION
## Summary
- export config module publicly
- re-export pool config in new crate-level module
- document config loading in README

## Testing
- `cargo check`
- `cargo test` *(fails: Worker dropped / PoolTimedOut)*

------
https://chatgpt.com/codex/tasks/task_e_683ec594ebac832fa2f5ef03a413611c