### PR TITLE
Add test pool convenience

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,8 @@ async-trait = "0.1.88"
 tracing = "0.1.41"
 
 [dev-dependencies]
-sea-orm = { version = "0.12", features = ["sqlx-postgres", "macros", "runtime-tokio-rustls"] }
+sea-orm = { version = "0.12", features = ["sqlx-postgres", "macros", "runtime-tokio-rustls", "mock"] }
+
+[features]
+mock = []
 

--- a/README.md
+++ b/README.md
@@ -85,9 +85,11 @@ The following table lists the main Lifeguard macros:
 | `lifeguard_query` | run SeaORM query and return result |
 | `lifeguard_insert_many` | `insert_many` |
 | `lifeguard_txn` | transaction wrapper |
+| `test_pool!` | create a mock `DbPoolManager` |
 
 ```rust
 // Using Lifeguard macros
+let pool = test_pool!();
 lifeguard_execute!(pool, { /* raw statement */ });
 let row = lifeguard_query!(pool, Entity::find().one(db));
 lifeguard_insert_many!(pool, pets::Entity, models);
@@ -166,6 +168,13 @@ just setup             # Start database + apply migrations
 just metrics-server    # Expose Prometheus metrics on :9898
 just seed-db-heavy n=100000 -- --batch-size=500
 just test              # Run tests
+```
+
+Use `test_pool!()` inside unit tests to create a mock `DbPoolManager` without a
+database:
+
+```rust
+let pool = test_pool!();
 ```
 
 ---

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -6,3 +6,19 @@ mod seed_test;
 mod temp_table;
 mod test_data;
 pub mod txn;
+
+#[allow(unused_imports)]
+use crate::pool::config::DatabaseConfig;
+#[allow(unused_imports)]
+use crate::DbPoolManager;
+
+/// Build a [`DbPoolManager`] backed by `MockDatabase` for unit tests.
+#[macro_export]
+macro_rules! test_pool {
+    () => {{
+        use sea_orm::{DatabaseBackend, MockDatabase};
+        $crate::DbPoolManager::from_connection(
+            MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
+        )
+    }};
+}

--- a/src/pool/worker.rs
+++ b/src/pool/worker.rs
@@ -1,13 +1,14 @@
 use crate::pool::types::{DbRequest, DbTask, LifeguardJob};
 use crossbeam_channel::Receiver;
 use sea_orm::*;
+use std::sync::Arc;
 
 /// The worker thread entrypoint that handles both macro and async jobs.
 pub async fn run_worker_loop(rx: Receiver<LifeguardJob>, db: DatabaseConnection) {
     while let Ok(job) = rx.recv() {
         match job {
             LifeguardJob::Macro(DbRequest::Execute { job, response_tx }) => {
-                let db = db.clone();
+                let db = clone_connection(&db);
                 let fut = job(db);
                 let result = fut.await;
                 let _ = response_tx.send(result);
@@ -33,5 +34,35 @@ pub async fn run_worker_loop(rx: Receiver<LifeguardJob>, db: DatabaseConnection)
                 let _ = tx.send(res);
             }
         }
+    }
+}
+
+#[cfg(not(feature = "mock"))]
+fn clone_connection(db: &DatabaseConnection) -> DatabaseConnection {
+    db.clone()
+}
+
+#[cfg(feature = "mock")]
+fn clone_connection(db: &DatabaseConnection) -> DatabaseConnection {
+    match db {
+        DatabaseConnection::SqlxPostgresPoolConnection(conn) => {
+            DatabaseConnection::SqlxPostgresPoolConnection(conn.clone())
+        }
+        #[cfg(feature = "sqlx-mysql")]
+        DatabaseConnection::SqlxMySqlPoolConnection(conn) => {
+            DatabaseConnection::SqlxMySqlPoolConnection(conn.clone())
+        }
+        #[cfg(feature = "sqlx-sqlite")]
+        DatabaseConnection::SqlxSqlitePoolConnection(conn) => {
+            DatabaseConnection::SqlxSqlitePoolConnection(conn.clone())
+        }
+        #[cfg(feature = "proxy")]
+        DatabaseConnection::ProxyDatabaseConnection(conn) => {
+            DatabaseConnection::ProxyDatabaseConnection(Arc::clone(conn))
+        }
+        DatabaseConnection::MockDatabaseConnection(conn) => {
+            DatabaseConnection::MockDatabaseConnection(Arc::clone(conn))
+        }
+        DatabaseConnection::Disconnected => DatabaseConnection::Disconnected,
     }
 }


### PR DESCRIPTION
## Summary
- enable SeaORM mock feature in dev setup
- allow constructing DbPoolManager from an existing connection
- expose new `test_pool!` macro
- document the macro in README
- adjust worker to handle uncloneable mock connections

## Testing
- `cargo test --features mock` *(fails: Failed to connect to the database)*

------
https://chatgpt.com/codex/tasks/task_e_683ee3e9e294832fbe82ac14f1b38671