### PR TITLE
Switch tests to test_pool macro

### DIFF
--- a/src/macros/go.rs
+++ b/src/macros/go.rs
@@ -42,22 +42,30 @@ mod tests {
     };
     #[allow(unused_imports)]
     use crate::DbPoolManager;
-    // #[test]
-    // fn test_lifeguard_go_macro_with_return_binding() -> Result<(), sea_orm::DbErr> {
-    //     let pool = DbPoolManager::from_config(&DatabaseConfig {
-    //         url: "postgres://postgres:postgres@localhost:5432/postgres".to_string(),
-    //         max_connections: 1,
-    //         pool_timeout_seconds: 5,
-    //     })?;
-    //
-    //     lifeguard_go!(pool, pet_name, {
-    //         let row = Pets::find_by_id(1).one(&pool).await?.unwrap_or_else(|| {
-    //             panic!("Mocked database should return a row for ID 1");
-    //         });
-    //         Ok::<_, DbErr>(row.name)
-    //     });
-    //
-    //     assert_eq!(pet_name, Ok("mocked name".to_string()));
-    //     Ok(())
-    // }
+
+    #[tokio::test]
+    async fn test_lifeguard_go_macro_with_return_binding() -> Result<(), sea_orm::DbErr> {
+        use sea_orm::{DatabaseBackend, MockDatabase};
+
+        let pool = test_pool!(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![vec![Pets::Model {
+                    id: 1,
+                    name: "mocked name".to_string(),
+                    species: "Dog".to_string(),
+                    owner_id: None,
+                }]])
+        );
+
+        lifeguard_go!(pool, pet_name, {
+            let row = Pets::find_by_id(1)
+                .one(&pool)
+                .await?
+                .unwrap();
+            Ok::<_, DbErr>(row.name)
+        });
+
+        assert_eq!(pet_name?, "mocked name".to_string());
+        Ok(())
+    }
 }

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -21,4 +21,7 @@ macro_rules! test_pool {
             MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
         )
     }};
+    ($mock:expr) => {{
+        $crate::DbPoolManager::from_connection($mock.into_connection())
+    }};
 }


### PR DESCRIPTION
## Summary
- add parameterized `test_pool!` macro variant
- rewrite `lifeguard_go` test to use mock DB
- start adapting `DbPoolManager` tests to mock pool

## Testing
- `cargo fmt --version` *(fails: component not installed)*


------
https://chatgpt.com/codex/tasks/task_e_683ee7e1c740832f90d7906f844fb460